### PR TITLE
Human friendly and Display for `UncheckedExtrinsic` & `Tx`

### DIFF
--- a/substrate-airgapped/Cargo.toml
+++ b/substrate-airgapped/Cargo.toml
@@ -10,7 +10,8 @@ codec = { package = "parity-scale-codec", version = "1.3.5", default-features = 
 
 # Substrate (hopefully these can be removed in the future)
 sp-runtime = { version = "2.0.1", default-features = false }
-sp-core = { version = "2.0.1", default-features = false }
+# TODO remove std or put it behind a feature gate
+sp-core = { version = "2.0.1", default-features = false, features = ["std"] }
 
 
 [dev-dependencies]

--- a/substrate-airgapped/examples/signed_tx_from_pair.rs
+++ b/substrate-airgapped/examples/signed_tx_from_pair.rs
@@ -1,9 +1,8 @@
-use codec::Encode;
 use primitive_types::H256;
 use sp_runtime::{generic::Header, traits::BlakeTwo256, DeserializeOwned};
 use substrate_airgapped::{
-	balances::Transfer, CallIndex, GenericCall, KusamaRuntime, MortalConfig, Mortality, Tx,
-	TxConfig,
+	balances::Transfer, uxt_as_hex, uxt_as_human, CallIndex, GenericCall, KusamaRuntime,
+	MortalConfig, Mortality, Tx, TxConfig,
 };
 
 // Example deps
@@ -48,11 +47,16 @@ fn main() -> Result<(), Error> {
 		tip: 100,
 	});
 
-	let signed_tx = tx.signed_tx_from_pair(AccountKeyring::Alice.pair()).expect("example to work");
-	println!("Tx (UncheckedExtrinsic): {:#?}\n", signed_tx);
+	println!("Tx (config):\n{}", tx);
 
-	let tx_encoded = hex::encode(signed_tx.encode());
-	println!("Submit this: {:#?}", tx_encoded);
+	let signed_uxt = tx.signed_uxt_from_pair(AccountKeyring::Alice.pair()).expect("example to work");
+	println!(
+		"Tx (UncheckedExtrinsic):\n{}",
+		uxt_as_human::<KusamaTransfer, KusamaRuntime>(&signed_uxt)
+	);
+
+	let uxt_encoded = uxt_as_hex::<KusamaTransfer, KusamaRuntime>(&signed_uxt);
+	println!("Submit this: {}", uxt_encoded);
 
 	Ok(())
 }
@@ -84,12 +88,7 @@ fn rpc_to_local_node<T: Serialize, U: DeserializeOwned>(
 	let client = reqwest::blocking::Client::new();
 
 	let req_body = RpcReq { jsonrpc: TWO_ZERO, id: 1, method, params };
-	client
-		.post(LOCAL_NODE_URL)
-		.json(&req_body)
-		.send()?
-		.json()
-		.map_err(Into::into)
+	client.post(LOCAL_NODE_URL).json(&req_body).send()?.json().map_err(Into::into)
 }
 
 // The below may be useful for those reading from file on an offline device... not sure where to put them

--- a/substrate-airgapped/examples/signed_tx_from_pair.rs
+++ b/substrate-airgapped/examples/signed_tx_from_pair.rs
@@ -1,7 +1,7 @@
 use primitive_types::H256;
 use sp_runtime::{generic::Header, traits::BlakeTwo256, DeserializeOwned};
 use substrate_airgapped::{
-	balances::Transfer, uxt_as_hex, uxt_as_human, CallIndex, GenericCall, KusamaRuntime,
+	balances::Transfer, tx_as_hex, tx_as_human, CallIndex, GenericCall, KusamaRuntime,
 	MortalConfig, Mortality, Tx, TxConfig,
 };
 
@@ -49,14 +49,14 @@ fn main() -> Result<(), Error> {
 
 	println!("Tx (config):\n{}", tx);
 
-	let signed_uxt = tx.signed_uxt_from_pair(AccountKeyring::Alice.pair()).expect("example to work");
+	let signed_tx = tx.signed_tx_from_pair(AccountKeyring::Alice.pair()).expect("example to work");
 	println!(
 		"Tx (UncheckedExtrinsic):\n{}",
-		uxt_as_human::<KusamaTransfer, KusamaRuntime>(&signed_uxt)
+		tx_as_human::<KusamaTransfer, KusamaRuntime>(&signed_tx)
 	);
 
-	let uxt_encoded = uxt_as_hex::<KusamaTransfer, KusamaRuntime>(&signed_uxt);
-	println!("Submit this: {}", uxt_encoded);
+	let tx_encoded = tx_as_hex::<KusamaTransfer, KusamaRuntime>(&signed_tx);
+	println!("Submit this: {}", tx_encoded);
 
 	Ok(())
 }

--- a/substrate-airgapped/src/frame/balances.rs
+++ b/substrate-airgapped/src/frame/balances.rs
@@ -1,6 +1,8 @@
 use super::{system::System, Parameter};
+use crate::{runtimes::Runtime, util::int_as_human};
 use codec::{Decode, Encode};
-use core::fmt::Debug;
+use core::fmt::{self, Debug, Display};
+use sp_core::crypto::Ss58Codec;
 use sp_runtime::traits::{AtLeast32Bit, MaybeSerialize, Member};
 
 /// The subset of the `pallet_balances::Trait` that a Runtime can implement.
@@ -14,7 +16,8 @@ pub trait Balances: System {
 		+ From<<Self as System>::BlockNumber>
 		+ Member
 		+ AtLeast32Bit
-		+ MaybeSerialize;
+		+ MaybeSerialize
+		+ Display; // This is not included in the substrate runtime, but helps us impl pretty print
 }
 
 /// Transfer some liquid free balance to another account.
@@ -38,4 +41,19 @@ where
 {
 	const CALL: &'static str = "transfer";
 	const PALLET: &'static str = "Balances";
+}
+
+impl<T> Display for Transfer<T>
+where
+	T: Balances + System + Runtime,
+{
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(
+			f,
+			"balances::Transfer\n{sp}to: {}\n{sp}amount: {}",
+			self.to.to_ss58check_with_version(<T as Runtime>::SS58_ADDRESS_FORMAT),
+			int_as_human(self.amount),
+			sp = format!("{:indent$}", "", indent = 8)
+		)
+	}
 }

--- a/substrate-airgapped/src/frame/system.rs
+++ b/substrate-airgapped/src/frame/system.rs
@@ -1,13 +1,14 @@
 use super::Parameter;
 use codec::{Codec, Decode};
-use core::fmt::Debug;
+use core::fmt::{Debug, Display};
+use sp_core::crypto::Ss58Codec;
 use sp_runtime::traits::AtLeast32Bit;
 
 /// Subset of the `pallet_system::Trait` the Runtime must implement.
 pub trait System {
 	/// Account index (aka nonce) type. This stores the number of previous transactions associated
 	/// with a sender account.
-	type Index: Parameter + Send + Sync + 'static + Debug + Default + AtLeast32Bit + Copy;
+	type Index: Parameter + Send + Sync + 'static + Debug + Default + AtLeast32Bit + Copy + Display;
 
 	/// The block number type used by the runtime.
 	type BlockNumber: Parameter
@@ -43,5 +44,6 @@ pub trait System {
 		+ Sync
 		+ Eq
 		+ Decode
-		+ From<Self::AccountId>;
+		+ From<Self::AccountId>
+		+ Ss58Codec; // TODO this should be conditional on std
 }

--- a/substrate-airgapped/src/lib.rs
+++ b/substrate-airgapped/src/lib.rs
@@ -12,7 +12,7 @@ pub use crate::{
 	frame::{balances, system, PalletCall},
 	runtimes::KusamaRuntime,
 	tx::{
-		uxt_as_hex, uxt_as_human, uxt_from_parts, CallIndex, GenericCall, GenericCallTrait,
+		tx_as_hex, tx_as_human, tx_from_parts, CallIndex, GenericCall, GenericCallTrait,
 		MortalConfig, Mortality, SignedPayload, Tx, TxConfig, UncheckedExtrinsic,
 	},
 };

--- a/substrate-airgapped/src/lib.rs
+++ b/substrate-airgapped/src/lib.rs
@@ -5,13 +5,14 @@ mod error;
 mod frame;
 mod runtimes;
 mod tx;
+mod util;
 
 pub use crate::{
 	error::Error,
 	frame::{balances, system, PalletCall},
 	runtimes::KusamaRuntime,
 	tx::{
-		tx_from_parts, CallIndex, GenericCall, MortalConfig, Mortality, SignedPayload, Tx,
-		TxConfig, UncheckedExtrinsic,
+		uxt_as_hex, uxt_as_human, uxt_from_parts, CallIndex, GenericCall, GenericCallTrait,
+		MortalConfig, Mortality, SignedPayload, Tx, TxConfig, UncheckedExtrinsic,
 	},
 };

--- a/substrate-airgapped/src/runtimes.rs
+++ b/substrate-airgapped/src/runtimes.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use codec::{Decode, Encode};
 use core::fmt::Debug;
+use sp_core::crypto::Ss58AddressFormat;
 use sp_runtime::{
 	traits::{IdentifyAccount, Verify},
 	MultiSignature,
@@ -15,6 +16,8 @@ pub trait Runtime: System + Balances + Sized + Send + Sync + 'static {
 	type Signature: Verify + Encode + Debug + Decode + Eq + Send + Sync + Clone + 'static;
 	/// Transaction extras.
 	type Extra: SignedExtra<Self> + Send + Decode + Sync + 'static;
+	/// SS58prefix associated with the network.
+	const SS58_ADDRESS_FORMAT: Ss58AddressFormat;
 }
 
 /// Kusama runtime specific types
@@ -24,6 +27,7 @@ pub struct KusamaRuntime;
 impl Runtime for KusamaRuntime {
 	type Signature = MultiSignature;
 	type Extra = DefaultExtra<Self>;
+	const SS58_ADDRESS_FORMAT: Ss58AddressFormat = Ss58AddressFormat::KusamaAccount;
 }
 
 impl System for KusamaRuntime {

--- a/substrate-airgapped/src/tx/mod.rs
+++ b/substrate-airgapped/src/tx/mod.rs
@@ -74,7 +74,7 @@ pub struct Tx<C: GenericCallTrait, R: System + Balances + Runtime> {
 }
 
 /// Create a tx from the senders address, a `SignedPayload` and the signature.
-pub fn uxt_from_parts<C, R>(
+pub fn tx_from_parts<C, R>(
 	sender: R::Address,
 	signature: R::Signature,
 	payload: SignedPayload<C, R>,
@@ -89,12 +89,12 @@ where
 }
 
 /// Get a human friendly form of an `UncheckedExtrinsic`.
-pub fn uxt_as_human<C, R>(uxt: &UncheckedExtrinsic<C, R>) -> String
+pub fn tx_as_human<C, R>(tx: &UncheckedExtrinsic<C, R>) -> String
 where
 	C: GenericCallTrait,
 	R: System + Balances + Runtime,
 {
-	let signature = match &uxt.signature {
+	let signature = match &tx.signature {
 		Some(sig) => {
 			format!(
 				"\n{sp}address: {}\n{sp}signature:\n{sp}{:#?}\n{sp}extra: {:#?}",
@@ -109,19 +109,19 @@ where
 
 	format!(
 		"call:\n{sp}{}\nsignature: {}",
-		uxt.function,
+		tx.function,
 		signature,
 		sp = format!("{:indent$}", "", indent = 4)
 	)
 }
 
 /// Get a hex form of an `UncheckedExtrinsic`.
-pub fn uxt_as_hex<C, R>(uxt: &UncheckedExtrinsic<C, R>) -> String
+pub fn tx_as_hex<C, R>(tx: &UncheckedExtrinsic<C, R>) -> String
 where
 	C: GenericCallTrait,
 	R: System + Balances + Runtime,
 {
-	let encoded = uxt.encode();
+	let encoded = tx.encode();
 
 	format!("0x{}", HexDisplay::from(&encoded))
 }
@@ -209,16 +209,16 @@ impl<C: GenericCallTrait, R: System + Balances + Runtime> Tx<C, R> {
 	}
 
 	/// Create a signed `UncheckedExtrinsic` (AKA transaction) using the given keyring pair to sign.
-	pub fn signed_uxt_from_pair<P>(&self, pair: P) -> Result<UncheckedExtrinsic<C, R>, Error>
+	pub fn signed_tx_from_pair<P>(&self, pair: P) -> Result<UncheckedExtrinsic<C, R>, Error>
 	where
 		P: Pair,
 		<R as Runtime>::Signature: From<<P as sp_core::Pair>::Signature>,
 	{
 		let payload = self.signed_payload()?;
 		let signature = payload.using_encoded(|payload| pair.sign(payload));
-		let uxt = uxt_from_parts::<C, R>(self.address.clone(), signature.into(), payload);
+		let tx = tx_from_parts::<C, R>(self.address.clone(), signature.into(), payload);
 
-		Ok(uxt)
+		Ok(tx)
 	}
 }
 

--- a/substrate-airgapped/src/tx/mortality.rs
+++ b/substrate-airgapped/src/tx/mortality.rs
@@ -1,4 +1,5 @@
-use crate::frame::system::System;
+use crate::{frame::system::System, util::int_as_human};
+use core::fmt::{self, Display};
 
 /// Mortal period configuration options,
 ///
@@ -13,6 +14,19 @@ pub struct MortalConfig<R: System> {
 	pub checkpoint_block_number: u64,
 }
 
+impl<R: System> Display for MortalConfig<R> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(
+			f,
+			"{sp}period: {}\n{sp}checkpoint_block_number: {}\n{sp}checkpoint_block_hash: {:#?}",
+			self.period,
+			int_as_human(self.checkpoint_block_number),
+			self.checkpoint_block_hash,
+			sp = format!("{:indent$}", "", indent = 8)
+		)
+	}
+}
+
 /// Specify the mortality of a transaction.
 ///
 /// Read here for conceptual details: https://docs.rs/sp-runtime/2.0.0/sp_runtime/generic/enum.Era.html
@@ -22,4 +36,13 @@ pub enum Mortality<R: System> {
 	Mortal(MortalConfig<R>),
 	/// Specify an immortal transaction.
 	Immortal,
+}
+
+impl<R: System> Display for Mortality<R> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Mortality::Mortal(config) => write!(f, "Mortal:\n{}", config),
+			Mortality::Immortal => write!(f, "Immortal"),
+		}
+	}
 }

--- a/substrate-airgapped/src/util.rs
+++ b/substrate-airgapped/src/util.rs
@@ -15,7 +15,8 @@ pub(crate) fn int_as_human<T: fmt::Display>(bal: T) -> String {
 }
 
 /// Simple wrapper to display hex representation of bytes.
-// Taken from sp_core::hexdisplay to remove reliance on deps
+///
+/// Same as `sp_core::hexdisplay::HexDisplay`. Re-defined to make it easier to remove dependance on `sp-core`.
 pub(crate) struct HexDisplay<'a>(&'a [u8]);
 
 impl<'a> HexDisplay<'a> {
@@ -36,7 +37,8 @@ impl<'a> core::fmt::Display for HexDisplay<'a> {
 }
 
 /// Simple trait to transform various types to `&[u8]`
-// Taken from sp_core::hexdisplay to remove reliance on deps
+///
+/// Same as `sp_core::hexdisplay::AsBytesRef`. Re-defined to make it easier to remove dependance on `sp-core`.
 pub(crate) trait AsBytesRef {
 	/// Transform `self` into `&[u8]`.
 	fn as_bytes_ref(&self) -> &[u8];

--- a/substrate-airgapped/src/util.rs
+++ b/substrate-airgapped/src/util.rs
@@ -1,0 +1,61 @@
+use core::fmt;
+
+// Pretty print an integer with commas every three digits.
+pub(crate) fn int_as_human<T: fmt::Display>(bal: T) -> String {
+	let mut pretty_bal = String::new();
+	let bal_str = bal.to_string();
+	for (idx, val) in bal_str.chars().rev().enumerate() {
+		if idx != 0 && idx % 3 == 0 {
+			pretty_bal.insert(0, ',');
+		}
+		pretty_bal.insert(0, val);
+	}
+
+	pretty_bal
+}
+
+/// Simple wrapper to display hex representation of bytes.
+// Taken from sp_core::hexdisplay to remove reliance on deps
+pub(crate) struct HexDisplay<'a>(&'a [u8]);
+
+impl<'a> HexDisplay<'a> {
+	/// Create new instance that will display `d` as a hex string when displayed.
+	pub fn from<R: AsBytesRef>(d: &'a R) -> Self {
+		HexDisplay(d.as_bytes_ref())
+	}
+}
+
+impl<'a> core::fmt::Display for HexDisplay<'a> {
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
+		for byte in self.0 {
+			f.write_fmt(format_args!("{:02x}", byte))?;
+		}
+
+		Ok(())
+	}
+}
+
+/// Simple trait to transform various types to `&[u8]`
+// Taken from sp_core::hexdisplay to remove reliance on deps
+pub(crate) trait AsBytesRef {
+	/// Transform `self` into `&[u8]`.
+	fn as_bytes_ref(&self) -> &[u8];
+}
+
+impl AsBytesRef for &[u8] {
+	fn as_bytes_ref(&self) -> &[u8] {
+		self
+	}
+}
+
+impl AsBytesRef for [u8] {
+	fn as_bytes_ref(&self) -> &[u8] {
+		&self
+	}
+}
+
+impl AsBytesRef for Vec<u8> {
+	fn as_bytes_ref(&self) -> &[u8] {
+		&self
+	}
+}


### PR DESCRIPTION
The goal with having high quality display methods is to afford library users (including CLIs) the ability to display accurate information for verifying the information of a transaction at all steps in the construction process. In particular, I think having human friendly forms of addresses, integers, and units of integers are particularly helpful

## Changes

- implement `fmt::Display` for `Tx` and the components of `Tx` that needed display methods
- methods for displaying `UncheckedExtrinsic` in human friendly form and hex (a form it can be submitted directly to the node as).
- `SS58_FORMAT` constant for `Runtime` to improve readability of addresses

## TODO

- [ ] Display units for token values (i.e Planck)
- [ ] Tests for how Display methods print to `stdout`
- [ ] Implement `std` feature (might do in another PR)